### PR TITLE
Change PG env var names

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const debugOn = args[0] === "--debug";
 
 const app = express();
 // get environment variables
-const { PORT: port, USER: user, PASSWORD: password } = process.env;
+const { PORT: port, PG_USER: user, PG_PASSWORD: password } = process.env;
 
 const pool = new Pool({
   user,


### PR DESCRIPTION
Candidates were getting confused about what the `USER` / `PORT` env vars meant, so we're switching this to be `PG_PORT` and `PG_PASSWORD`.
